### PR TITLE
fix(tiktok): Use legacy_server_connect to fix SSL EOF error

### DIFF
--- a/main.py
+++ b/main.py
@@ -503,6 +503,7 @@ def run_yt_dlp(url: str, dst: Path) -> dict:
                 "max_sleep_interval": 5,
                 "ignoreerrors": False,
                 "no_check_certificate": True,
+                "legacy_server_connect": True,  # Fix for SSL EOF errors with TikTok
                 # Prefer mobile API via extractor_args
                 "extractor_args": {
                     "tiktok": {


### PR DESCRIPTION
This change addresses an `ssl.SSLEOFError: [SSL: UNEXPECTED_EOF_WHILE_READING]` that occurs when `yt-dlp` attempts to download videos from TikTok. The error indicates that the TikTok server is prematurely closing the TLS connection, likely due to TLS fingerprinting.

To resolve this, the `legacy_server_connect` option has been enabled in the `yt-dlp` parameters for all TikTok requests. This option allows `yt-dlp` to use a more permissive set of SSL/TLS configurations, which can help establish a successful connection with servers that have non-standard or strict handshake requirements.

This is a targeted fix that only affects TikTok downloads and should not impact other platforms.