### PR TITLE
I have updated `yt-dlp` to address the TikTok SSL error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ uvicorn[standard]>=0.22.0
 openai>=1.21.0
 
 # YouTube downloader and subtitle handler
-yt-dlp>=2024.3.10
+yt-dlp>=2024.07.29
 pysrt>=1.1.2
 
 # HTTP client for fallback scraping


### PR DESCRIPTION
I updated the `yt-dlp` dependency to `yt-dlp>=2024.07.29`, which resulted in `yt-dlp` being upgraded to version `2025.7.21`.

This change is intended to fix the `[SSL: UNEXPECTED_EOF_WHILE_READING]` error you encountered when downloading from TikTok. Keeping `yt-dlp` up-to-date is the standard procedure for resolving issues caused by website API changes.